### PR TITLE
Support all custom-rendered CSS properties

### DIFF
--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -367,10 +367,13 @@ module Component = [%styled {|
   } */
 |}];
 
-module EM = [%styled {|flex-grow: 1;|}];
+module EM = [%styled {|
+  margin: 10% auto;
+  margin-top: 10%;
+|}];
 
 module M = {
-  let styled = Emotion.(css([flexGrow(1.)]));
+  let styled = Emotion.(css([margin3(px(2), px(2), px(4))]));
   [@react.component]
   let make = (~children) => <div className=styled> children </div>;
 };

--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -367,9 +367,20 @@ module Component = [%styled {|
   } */
 |}];
 
+/* module M = [%styled "z-index: 100"]; */
+
+module M = {
+  let styled = Emotion.(css([zIndex(1000)]));
+  [@react.component]
+  let make = (~children) => <div className=styled> children </div>;
+};
+
 ReactDOMRe.renderToElementWithId(
   <Component>
     {React.string("React API")}
+    <M>
+      {React.string("zindexxx")}
+    </M>
   </Component>,
   "app"
 );

--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -367,10 +367,10 @@ module Component = [%styled {|
   } */
 |}];
 
-module EM = [%styled {|font-weight: 400;|}];
+module EM = [%styled {|flex-grow: 1;|}];
 
 module M = {
-  let styled = Emotion.(css([fontWeight(400)]));
+  let styled = Emotion.(css([flexGrow(1.)]));
   [@react.component]
   let make = (~children) => <div className=styled> children </div>;
 };

--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -1,5 +1,4 @@
-module Component = [%styled
-  {|
+module Component = [%styled {|
   display: flex;
   align-items: center;
   justify-content: center;
@@ -122,7 +121,7 @@ module Component = [%styled
   /* dominant-baseline: auto; */
   /* empty-cells: show; */
   fill: rgb(0, 0, 0);
-  fill-opacity: 1;
+  /* fill-opacity: 1; */
   /* fill-rule: nonzero; */
   filter: none;
   flex-basis: auto;
@@ -132,7 +131,7 @@ module Component = [%styled
   flex-wrap: nowrap;
   float: none;
   /* flood-color: rgb(0, 0, 0); */
-  flood-opacity: 1;
+  /* flood-opacity: 1; */
   /* font-family: Times; */
   /* font-feature-settings: normal; */
   font-kerning: auto;
@@ -199,7 +198,7 @@ module Component = [%styled
   /* offset-distance: 0px; */
   /* offset-path: none; */
   /* offset-rotate: auto 0deg; */
-  opacity: 1;
+  /* opacity: 1; */
   /* order: 0; */
   /* orphans: 2; */
   outline-color: rgb(255, 255, 255);
@@ -259,14 +258,14 @@ module Component = [%styled
   /* shape-rendering: auto; */
   /* speak: normal; */
   stop-color: rgb(0, 0, 0);
-  stop-opacity: 1;
+  /* stop-opacity: 1; */
   /* stroke: none; */
   /* stroke-dasharray: none; */
   /* stroke-dashoffset: 0px; */
   /* stroke-linecap: butt; */
   /* stroke-linejoin: miter; */
   /* stroke-miterlimit: 4; */
-  stroke-opacity: 1;
+  /* stroke-opacity: 1; */
   stroke-width: 1px;
   /* tab-size: 8; */
   table-layout: auto;
@@ -366,21 +365,11 @@ module Component = [%styled
   /* &:hover {
     color: #000000;
   } */
-|}
-];
-
-module StyledComponent = [%styled "opacity: 0.9"];
-
-module Emotion = {
-  let styles = Emotion.(css([opacity(0.3)]));
-  [@react.component]
-  let make = (~children) => <div className=styles> children </div>;
-};
+|}];
 
 ReactDOMRe.renderToElementWithId(
-  <>
-    <StyledComponent> {React.string("React API")} </StyledComponent>
-    <Emotion> {React.string("React API")} </Emotion>
-  </>,
-  "app",
+  <Component>
+    {React.string("React API")}
+  </Component>,
+  "app"
 );

--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -1,26 +1,6 @@
 module Component = [%styled {|
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 200px;
-  height: 200px;
-
-  border-radius: 4px;
-  border-radius: 2%;
-
-  font-size: 24px;
-
-  /* margin: 10; */
-  /* margin: 10px 5px; */
-  margin: 5px;
-  padding: 5px;
-  padding-top: 2px;
-  padding-bottom: 2px;
-
-  /* box-shadow: 5px 4px #ebebeb; */
-
-  /* transition-property: border-radius; */
-  /* transition-duration: 100ms; */
+  /* "any": inherit; */
+  /* "any": unset; */
 
   /* Ordered list of default properties */
   align-content: normal;
@@ -83,6 +63,7 @@ module Component = [%styled {|
   border-top-style: none;
   border-top-width: 0px;
   bottom: auto;
+  bottom: 20px;
   /* box-shadow: none; */
   /* box-sizing: content-box; */
   /* break-after: auto; */
@@ -95,8 +76,8 @@ module Component = [%styled {|
   /* clip: auto; */
   clip-path: none;
   /* clip-rule: nonzero; */
-  color: rgb(255, 255, 255);
   /* color: white */
+  color: rgb(255, 255, 255);
   /* color-interpolation: srgb; */
   /* color-interpolation-filters: linearrgb; */
   /* color-rendering: auto; */
@@ -123,6 +104,9 @@ module Component = [%styled {|
   fill: rgb(0, 0, 0);
   /* fill-opacity: 1; */
   /* fill-rule: nonzero; */
+  /* flex: 1; */
+  /* flex: 1 1; */
+  flex: 1 1 100px;
   filter: none;
   flex-basis: auto;
   flex-direction: column;
@@ -131,7 +115,7 @@ module Component = [%styled {|
   flex-wrap: nowrap;
   float: none;
   /* flood-color: rgb(0, 0, 0); */
-  /* flood-opacity: 1; */
+  flood-opacity: 1;
   /* font-family: Times; */
   /* font-feature-settings: normal; */
   font-kerning: auto;
@@ -144,7 +128,8 @@ module Component = [%styled {|
   /* font-variant-ligatures: normal; */
   /* font-variant-numeric: normal; */
   /* font-variation-settings: normal; */
-  /* font-weight: 400; */
+  font-weight: 400;
+  /* font-weight: bold; */
   grid-auto-columns: auto;
   grid-auto-flow: row;
   grid-auto-rows: auto;
@@ -156,6 +141,7 @@ module Component = [%styled {|
   grid-template-columns: none;
   grid-template-rows: none;
   height: 200px;
+  height: auto;
   /* hyphens: manual; */
   /* image-rendering: auto; */
   /* inline-size: 200px; */
@@ -179,6 +165,10 @@ module Component = [%styled {|
   margin-left: 5px;
   margin-right: 5px;
   margin-top: 5px;
+  margin-bottom: 5px;
+  margin: 10px 5px;
+  margin: 10px 5px 10px;
+  margin: 5px;
   /* marker-end: none; */
   /* marker-mid: none; */
   /* marker-start: none; */
@@ -198,7 +188,7 @@ module Component = [%styled {|
   /* offset-distance: 0px; */
   /* offset-path: none; */
   /* offset-rotate: auto 0deg; */
-  /* opacity: 1; */
+  opacity: 1;
   /* order: 0; */
   /* orphans: 2; */
   outline-color: rgb(255, 255, 255);
@@ -215,12 +205,16 @@ module Component = [%styled {|
   /* overscroll-behavior-y: auto; */
   /* padding-block-end: 2px; */
   /* padding-block-start: 2px; */
-  padding-bottom: 2px;
   /* padding-inline-end: 5px; */
   /* padding-inline-start: 5px; */
   padding-left: 5px;
   padding-right: 5px;
   padding-top: 2px;
+  padding-bottom: 2px;
+  padding: 5px 10px;
+  padding: 5px 10px 5px;
+  padding: 5px 10px 5px 3px;
+  padding: 5px;
   /* paint-order: normal; */
   perspective: none;
   perspective-origin: 105px 102px;
@@ -310,6 +304,7 @@ module Component = [%styled {|
   /* x: 0px; */
   /* y: 0px; */
   /* z-index: auto; */
+  z-index: 100;
   /* zoom: 1; */
   /* -webkit-app-region: none; */
   /* -webkit-appearance: none; */
@@ -367,13 +362,13 @@ module Component = [%styled {|
   } */
 |}];
 
-module EM = [%styled {|
-  margin: 10% auto;
-  margin-top: 10%;
-|}];
+  /* transition: all 500ms ease; */
+module EM = [%styled {| flex: 1 0 auto; |}];
 
 module M = {
-  let styled = Emotion.(css([margin3(px(2), px(2), px(4))]));
+  let styled = Emotion.(css([
+    flex(`some(1., 1., pct(90.)))
+  ]));
   [@react.component]
   let make = (~children) => <div className=styled> children </div>;
 };

--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -125,7 +125,7 @@ module Component = [%styled {|
   /* fill-rule: nonzero; */
   filter: none;
   flex-basis: auto;
-  flex-direction: row;
+  flex-direction: column;
   flex-grow: 0;
   flex-shrink: 1;
   flex-wrap: nowrap;
@@ -367,17 +367,19 @@ module Component = [%styled {|
   } */
 |}];
 
-/* module M = [%styled "z-index: 100"]; */
+module EM = [%styled {|font-weight: 400;|}];
 
 module M = {
-  let styled = Emotion.(css([zIndex(1000)]));
+  let styled = Emotion.(css([fontWeight(400)]));
   [@react.component]
   let make = (~children) => <div className=styled> children </div>;
 };
 
 ReactDOMRe.renderToElementWithId(
   <Component>
-    {React.string("React API")}
+    <EM>
+      {React.string("React API")}
+    </EM>
     <M>
       {React.string("zindexxx")}
     </M>

--- a/src/css_to_emotion.re
+++ b/src/css_to_emotion.re
@@ -1006,10 +1006,9 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
       if (List.length(vs) == 1) {
         let (v, loc) as c = List.hd(vs);
         switch (v) {
-        | Ident(_) => rcv(c)
-        | Number(_) =>
-          let ident = Exp.ident(~loc=name_loc, {txt: Lident("int"), loc});
-          Exp.apply(~loc, ident, [(Nolabel, rcv(c))]);
+        /* | Ident(_) => rcv(c) */
+        | Number(n) =>
+          Exp.constant(~loc, Pconst_integer(n, None));
         | _ => grammar_error(loc, "Unexpected z-index value")
         };
       } else {

--- a/src/css_to_emotion.re
+++ b/src/css_to_emotion.re
@@ -1107,9 +1107,8 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
   let render_margin_padding = () => {
     let (vs, _) = d.Declaration.value;
     let parameter_count = List.length(vs);
-    let fnNameN = parameter_count > 1
-      ? fnName ++ string_of_int(parameter_count)
-      : fnName;
+    let fnNameN =
+      parameter_count > 1 ? fnName ++ string_of_int(parameter_count) : fnName;
 
     let ident =
       Exp.ident(~loc=name_loc, {txt: Lident(fnNameN), loc: name_loc});
@@ -1153,9 +1152,15 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
   | "font-weight" => render_font_weight()
   | "padding"
   | "margin" => render_margin_padding()
-  | "background-position"
-  /* | "transform-origin" => render_margin_padding()
-     | "flex" => render_margin_padding() */
+  /* | "background-position"
+     | "transform-origin" => render_margin_padding()
+     | "flex" => render_margin_padding()  */
+
+/* border-top-right-radius
+   border-top-left-radius
+   border-bottom-right-radius
+   border-bottom-left-radius
+*/
   | "border"
   | "outline" when List.length(fst(d.Declaration.value)) == 2 =>
     render_border_outline()

--- a/src/css_to_emotion.re
+++ b/src/css_to_emotion.re
@@ -991,7 +991,7 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
     let ident =
       Exp.ident(
         ~loc=name_loc,
-        {txt: Lident("fontFamilies"), loc: name_loc},
+        {txt: Lident("fontFamily"), loc: name_loc},
       );
     Exp.apply(
       ~loc=name_loc,
@@ -1006,7 +1006,7 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
       if (List.length(vs) == 1) {
         let (v, loc) as c = List.hd(vs);
         switch (v) {
-        /* | Ident(_) => rcv(c) */
+        | Ident(_) => rcv(c)
         | Number(n) =>
           Exp.constant(~loc, Pconst_integer(n, None));
         | _ => grammar_error(loc, "Unexpected z-index value")
@@ -1046,8 +1046,8 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
         let (v, loc) as c = List.hd(vs);
         switch (v) {
         | Ident(_) => rcv(c)
-        | Number(_) => Exp.variant(~loc, "num", Some(rcv(c)))
-        | _ => grammar_error(loc, "Unexpected font-weight value")
+        | Number(n) => Exp.constant(~loc, Pconst_integer(n, None));
+        | _ => grammar_error(loc, "Unexpected font-weight value, expects an integer")
         };
       } else {
         grammar_error(loc, "font-weight should have a single value");

--- a/src/css_to_emotion.re
+++ b/src/css_to_emotion.re
@@ -661,6 +661,7 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
   open Component_value;
   let rcv = render_component_value;
   let (name, name_loc) = d.Declaration.name;
+  let fnName = to_caml_case(name);
 
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/animation */
   let render_animation = () => {
@@ -1016,12 +1017,32 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
       };
 
     let ident =
-      Exp.ident(~loc=name_loc, {txt: Lident("zIndex"), loc: name_loc});
+      Exp.ident(~loc=name_loc, {txt: Lident(fnName), loc: name_loc});
     Exp.apply(~loc=name_loc, ident, [(Nolabel, arg)]);
   };
 
+/*  TODO: Initial abstraction over custom-renders
+
+    let renderHoF = (value, name, number_to_exp) => {
+    let fnName = to_caml_case(name);
+    let (vs, loc) = value;
+    let arg =
+      if (List.length(vs) == 1) {
+        let (v, loc) = List.hd(vs);
+        switch (v) {
+        | Number(n) => number_to_exp(n)
+        | _ => grammar_error(loc, "Unexpected " ++ name ++ " value")
+        };
+      } else {
+        grammar_error(loc, name ++ " should have a single value");
+      };
+
+    let ident =
+      Exp.ident(~loc=name_loc, {txt: Lident(fnName), loc: name_loc});
+    Exp.apply(~loc=name_loc, ident, [(Nolabel, arg)]);
+  }; */
+
   let render_flex_grow_shrink = () => {
-    let name = to_caml_case(name);
     let (vs, loc) = d.Declaration.value;
     let arg =
       if (List.length(vs) == 1) {
@@ -1035,7 +1056,7 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
       };
 
     let ident =
-      Exp.ident(~loc=name_loc, {txt: Lident(name), loc: name_loc});
+      Exp.ident(~loc=name_loc, {txt: Lident(fnName), loc: name_loc});
     Exp.apply(~loc=name_loc, ident, [(Nolabel, arg)]);
   };
 
@@ -1054,7 +1075,7 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
       };
 
     let ident =
-      Exp.ident(~loc=name_loc, {txt: Lident("fontWeight"), loc: name_loc});
+      Exp.ident(~loc=name_loc, {txt: Lident(fnName), loc: name_loc});
     Exp.apply(~loc=name_loc, ident, [(Nolabel, arg)]);
   };
 
@@ -1077,9 +1098,9 @@ and render_declaration = (d: Declaration.t, d_loc: Location.t): expression => {
 
     let (params, loc) = d.Declaration.value;
     let args = border_outline_args(params, loc);
-    let name = to_caml_case(name) ++ "2";
+    let fnName2 = fnName ++ "2";
     let ident =
-      Exp.ident(~loc=name_loc, {txt: Lident(name), loc: name_loc});
+      Exp.ident(~loc=name_loc, {txt: Lident(fnName2), loc: name_loc});
     Exp.apply(ident, args);
   };
 

--- a/test/simple.ml
+++ b/test/simple.ml
@@ -1,4 +1,4 @@
-module Component = [%styled ("z-index: 100")]
+module Component = [%styled ("display: block")]
 
 (*
 

--- a/test/simple.ml
+++ b/test/simple.ml
@@ -1,4 +1,4 @@
-module Component = [%styled ("display: block")]
+module Component = [%styled ("z-index: 100")]
 
 (*
 


### PR DESCRIPTION
This is a WIP for https://github.com/davesnx/re-styled-ppx/issues/7

This is the first chunk of properties that are half-supported and I think are a minimum to create any sort of styles. Rendering those properties correctly we would unlock many more, like supporting `opacity` you unlock:  `stroke-opacity` `stop-opacity` `flood-opacity` `fill-opacity`.

- [ ] ~`animation`~
- [ ] ~`box-shadow`~
- [ ] ~`text-shadow`~
- [x] `transform`
- [ ] ~`transition`~
- [ ] ~`font-family`~
- [x] `z-index`
- [x] `opacity`
- [x] `flex-grow`
- [x] `flex-shrink`
- [x] `font-weight`
- [x] `padding`
- [x] `margin`
- [x] `border-top-right-radius`
- [x] `border-top-left-radius`
- [x] `border-bottom-right-radius`
- [x] `border-bottom-left-radius`
- [ ] ~`background-position`~
- [ ] ~`transform-origin`~
- [x] `flex`
- [x] `border`
- [x] `outline`